### PR TITLE
Bump PHP version to 8.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,28 +9,32 @@ integration_tests: &integration_tests
   environment:
     ST_ENGINE_NAME: php-integration-test-$CIRCLE_BUILD_NUM
   steps:
-  - install_deps
-  - run_integration_tests
+    - install_deps
+    - run_integration_tests
+
+php81: &php81
+  docker:
+  - image: cimg/php:8.1.7-browsers
 
 php73: &php73
   docker:
-  - image: circleci/php:7.3-browsers
+  - image: cimg/php:7.3-browsers
 
 php72: &php72
   docker:
-  - image: circleci/php:7.2-browsers
+  - image: cimg/php:7.2-browsers
 
 php71: &php71
   docker:
-  - image: circleci/php:7.1-browsers
+  - image: cimg/php:7.1-browsers
 
 php70: &php70
   docker:
-  - image: circleci/php:7.0-browsers
+  - image: cimg/php:7.0-browsers
 
 php56: &php56
   docker:
-  - image: circleci/php:5.6-browsers
+  - image: cimg/php:5.6-browsers
 
 commands:
 
@@ -67,6 +71,13 @@ commands:
         command: ST_ENGINE_NAME="php-integration-test-$CIRCLE_BUILD_NUM" vendor/bin/phpunit -c phpunit.xml.dist --testsuite integration
 
 jobs:
+  php-81-unit-tests:
+    <<: *unit_tests
+    <<: *php81
+
+  php-81-integration-tests:
+    <<: *integration_tests
+    <<: *php81
 
   php-73-unit-tests:
     <<: *unit_tests
@@ -130,6 +141,14 @@ workflows:
     jobs:
     - qa-phplint
     - qa-phpcs
+  
+  php-81-tests:
+    jobs:
+    - php-81-unit-tests
+    - php-81-integration-tests:
+        filters:
+            branches:
+              ignore: /pull.*/
   php-73-tests:
     jobs:
     - php-73-unit-tests

--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
     {"name" : "Aurélien FOUCRET", "email": "aurelien.foucret@elastic.co"}
   ],
   "require" : {
-    "php" : "^5.6|^7.0",
-    "elastic/openapi-codegen" : "^1.0.2",
+    "php" : "^5.6|^7.0|^8.0",
+    "elastic/openapi-codegen" : "^1.0.5",
     "psr/log" : "^1.0."
   },
   "require-dev" : {
-    "phpunit/phpunit" : "^5.6.0|^6.3.0",
+    "phpunit/phpunit" : "^5.6.0|^6.3.0|9.5.20",
     "squizlabs/php_codesniffer" : "^3.4.0",
     "symfony/yaml" : "*",
     "friendsofphp/php-cs-fixer": "^2.14",


### PR DESCRIPTION
### Description
In order to unblock our customers, it's required to bump the PHP version to 8.1

This PR is dedicated to bumping the PHP version and all related dependencies.