### PR TITLE
Fix openapi-codegen version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   ],
   "require" : {
     "php" : "^5.6|^7.0|^8.0",
-    "elastic/openapi-codegen" : "dev-fix/psr-log-version",
+    "elastic/openapi-codegen" : "^1.0.6",
     "psr/log" : "^1|^2|^3"
   },
   "require-dev" : {


### PR DESCRIPTION
Somehow I missed this in https://github.com/elastic/site-search-php/pull/21 🤦🏼 